### PR TITLE
Add dustjs-helpers for dust template engine

### DIFF
--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -255,7 +255,7 @@ function createApplication (name, path) {
         app.locals.modules.adaro = 'adaro'
         app.locals.view = {
           engine: 'dust',
-          render: 'adaro.dust()'
+          render: 'adaro.dust({helpers: ['dustjs-helpers']})'
         }
         break
       default:


### PR DESCRIPTION
To use the conditional helpers with Dust template engine, the dustjs-helpers module must be defined in adaro options object. The dustjs-helpers module is a dependency of adaro module, so there is no need to add it to package.json modules.